### PR TITLE
Configurable display of current user and IP address.  Better installation docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Powerline style prompt for oh-my-zsh
 Set Up
 ------
 
+### Manual / oh-my-zsh
 1. Clone the repository.
 
 	```
@@ -23,6 +24,17 @@ Set Up
     ```
     ZSH_THEME="solarized-powerline"
     ```
+
+### Antigen
+
+    antigen bundle KuoE0/oh-my-zsh-solarized-powerline-theme solarized-powerline
+
+Configuration
+-------------
+You can set following options in your .zshrc
+
+    export ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
+    export ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
 
 Test
 ----

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Configuration
 -------------
 You can set following options in your .zshrc
 
-    export ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
-    export ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
+    ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
+    ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
 
 Test
 ----

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Set Up
 
 ### Antigen
 
-    antigen bundle KuoE0/oh-my-zsh-solarized-powerline-theme solarized-powerline
+    antigen theme KuoE0/oh-my-zsh-solarized-powerline-theme solarized-powerline
 
 Configuration
 -------------

--- a/solarized-powerline.zsh-theme
+++ b/solarized-powerline.zsh-theme
@@ -1,3 +1,11 @@
+# You can set following options in your .zshrc
+#
+# export ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
+# export ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
+
+
+
+
 
 # OS detection
 if [ -n "${OS+x}" ]; then
@@ -77,13 +85,20 @@ ZSH_THEME_GIT_PROMPT_UNTRACKED="%F{190]✭%f"
 
 ZSH_TIME=%T
 
+# option defaults
+[[ -n "$ZSH_POWERLINE_SHOW_IP" ]]    || ZSH_POWERLINE_SHOW_IP=true
+[[ -n "$ZSH_POWERLINE_SHOW_USER" ]]  || ZSH_POWERLINE_SHOW_USER=true
+
 # username
 
 PROMPT="
-$FG_COLOR_4$BG_COLOR_7 %n"
+$FG_COLOR_4$BG_COLOR_7"
+
+if [ $ZSH_POWERLINE_SHOW_USER = true ]; then
+    PROMPT=$PROMPT"%n"
+fi
 
 # hostname
-[[ -n "$ZSH_POWERLINE_SHOW_IP" ]] || ZSH_POWERLINE_SHOW_IP=true
 
 if [ $ZSH_POWERLINE_SHOW_IP = true ]; then
     if [ "$(echo $IP | grep 200)" = "" ]; then

--- a/solarized-powerline.zsh-theme
+++ b/solarized-powerline.zsh-theme
@@ -83,17 +83,19 @@ PROMPT="
 $FG_COLOR_4$BG_COLOR_7 %n"
 
 # hostname
-IP=`curl -si --max-time 2 http://ipecho.net/plain`
+[[ -n "$ZSH_POWERLINE_SHOW_IP" ]] || ZSH_POWERLINE_SHOW_IP=true
 
-if [ "$(echo $IP | grep 200)" = "" ]; then
-	# no network connection, use hostname
-	IP="%m"
-else
-	# replace dot by dash
-	IP=`echo -n $IP | tail -n 1 | sed "s/\./-/g"`
+if [ $ZSH_POWERLINE_SHOW_IP = true ]; then
+    if [ "$(echo $IP | grep 200)" = "" ]; then
+    IP=`curl -si --max-time 2 http://ipecho.net/plain`
+        # no network connection, use hostname
+        IP="%m"
+    else
+        # replace dot by dash
+        IP=`echo -n $IP | tail -n 1 | sed "s/\./-/g"`
+    fi
+    PROMPT=$PROMPT"$FG_COLOR_2 at$FG_COLOR_13 $IP "
 fi
-
-PROMPT=$PROMPT"$FG_COLOR_2 at$FG_COLOR_13 $IP "
 
 PROMPT=$PROMPT"$FG_COLOR_7$BG_COLOR_10"$''
 

--- a/solarized-powerline.zsh-theme
+++ b/solarized-powerline.zsh-theme
@@ -1,7 +1,7 @@
 # You can set following options in your .zshrc
 #
-# export ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
-# export ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
+# ZSH_POWERLINE_SHOW_IP=true     # Display current IP in the prompt
+# ZSH_POWERLINE_SHOW_USER=true   # Display username in the prompt
 
 
 

--- a/solarized-powerline.zsh-theme
+++ b/solarized-powerline.zsh-theme
@@ -8,9 +8,7 @@
 
 
 # OS detection
-if [ -n "${OS+x}" ]; then
-	OS=$(uname)
-fi
+[[ -n "${OS}" ]] || OS=$(uname)
 
 # color
 BG_COLOR_BLACK=%{$bg[black]%}


### PR DESCRIPTION
Hi
I've made few enhancements:
- username display can be disabled, but I left it enabled by default for backward compatibility
- same for IP address/hostname
- antigen installation instructions
